### PR TITLE
Resize to size of background image

### DIFF
--- a/dalliclick.sh
+++ b/dalliclick.sh
@@ -50,6 +50,7 @@ HEIGHT=766
 GENERATE_MASK=0
 NUMSEGMENTS=10
 RESULTIMAGEBASE_GIVEN=1
+OUTPUTFILEFORMAT=png
 # do all output operations in a temporary dir? where should this be located?
 GENTMPDIR=0
 # OUTPUTDIR=`pwd`
@@ -72,6 +73,7 @@ function usage {
 	echo "-b background (canvas) image"
 	echo "-m maskimage (with label gray values 1,2,3,...)"
 	echo "-t do not generate temporary directory (working dir is used)"
+	echo "-O format of output files (png)"
         [[ $# -eq 1 ]] && exit $1 || exit $EXIT_FAILURE
 }
 
@@ -174,7 +176,7 @@ fi
 # parse options
 # Option -h (help) should always be there
 # if you have an option argument to be parsed use ':' after option
-while getopts ':n:i:b:m:o:vht' OPTION ; do
+while getopts ':n:i:b:m:o:O:vht' OPTION ; do
         case $OPTION in
         v)        VERBOSE=0
                 ;;
@@ -189,6 +191,8 @@ while getopts ':n:i:b:m:o:vht' OPTION ; do
 		RESULTIMAGEBASE_GIVEN=0
 		echo "given basename: "$RESULTIMAGEBASE;
 		;;
+	O)      OUTPUTFILEFORMAT="$OPTARG"
+	        ;;
 	b)	BACKGROUNDIMAGENAME="$OPTARG"
 		GENERATE_BACKGROUND=1
 		;;
@@ -261,7 +265,7 @@ do
 	
 	for THRESHOLD in `seq -w 0 1 "$NUMSEGMENTS"`
 	do
-		RESULTIMAGE="${RESULTIMAGEBASE}_$THRESHOLD.png"
+		RESULTIMAGE="${RESULTIMAGEBASE}_$THRESHOLD.$OUTPUTFILEFORMAT"
 		# debug: THRESHOLD=2
 		# generate black/white image from mask
 		# this is something to be worked out: 

--- a/dalliclick.sh
+++ b/dalliclick.sh
@@ -61,19 +61,27 @@ GRAYMASKDEFAULTFILENAME="tmp_maskimage.png"
 # generate a background image?
 GENERATE_BACKGROUND=1
 BACKGROUNDIMAGENAME="tmp_background.png"
+RESIZEIMAGENAME="tmp_resized.png"
+FILLUPCOLOR="black"
 
 # functions
 function usage {
 	echo "This script creates partially occluded image versions of the input image"
-        echo "Usage: $SCRIPTNAME <options> imagefiles" >&2
-	echo "-h (this) help"
-	echo "-v Increase verbosity (more details on actions)"
-	echo "-n number of segments, max. 255"
-	echo "-o output image base name (out -> out_NNN.png)"
-	echo "-b background (canvas) image"
-	echo "-m maskimage (with label gray values 1,2,3,...)"
-	echo "-t do not generate temporary directory (working dir is used)"
-	echo "-O format of output files (png)"
+        echo "Usage: $SCRIPTNAME <Options> imagefile..."
+	echo "Options:"
+	echo "-h             Show this help"
+	echo "-v             Increase verbosity (more details on actions)"
+	echo "-n Segments    Number of segments, max. 255 (Default 10)"
+	echo "-o Name        Output image base name (out -> out_NNN.png)"
+	echo "-b File        Background (canvas) image. The output images will have exactly"
+	echo "               the size of the background image."
+	echo "               If this is not specified, an artifical background image will be"
+	echo "               generated."
+	echo "-B color       Color for filling up images in wrong ratio (only relevant with -b)"
+	echo "-m maskimage   User specific mask image with label gray values 1,2,3,..."
+	echo "               If this is not specified a random mask image will be generated."
+	echo "-t             Do not generate temporary directory (working dir is used)"
+	echo "-O format      Format of output files (Default: png)"
         [[ $# -eq 1 ]] && exit $1 || exit $EXIT_FAILURE
 }
 
@@ -131,20 +139,17 @@ function dallicleanup(){
     # cleanup *generated* files
     if [ $GENERATE_BACKGROUND -ne 0 ] ; then
       # # remove 'starting' canvas
-      if [ -f "$BACKGROUNDIMAGE" ] ; then
-	rm "$BACKGROUNDIMAGE"
-      fi
+	rm -f "$BACKGROUNDIMAGE"
     fi
     #if [ $VERBOSE -ne 0 ] ; then  echo "cleaning up mask"; fi
     if [ $GENERATE_MASK -ne 0 ] ; then
       # # remove mask image
-      if [ -f "$TMPMASKIMAGENAME" ] ; then
-	rm "$TMPMASKIMAGENAME"
-      fi
+	rm -f "$TMPMASKIMAGENAME"
     fi
-    if [ -f "$GRAYMASKFILE" ] ; then
-      rm "$GRAYMASKFILE"
+    if [ "$INPUTIMAGERESIZED" ]; then
+	    rm -f "$INPUTIMAGERESIZED"
     fi
+    rm -f "$GRAYMASKFILE"
     # cleanup the temporary directory, if that was created
     #if [ $VERBOSE -ne 0 ] ; then  echo "cleaning up tmpdir"; fi
     if [ $GENTMPDIR -eq 0 ] ; then
@@ -152,6 +157,7 @@ function dallicleanup(){
 	      rm -rf "$TMPDIR"
 	    fi
     fi
+
 }
 
 function failbail(){
@@ -176,7 +182,7 @@ fi
 # parse options
 # Option -h (help) should always be there
 # if you have an option argument to be parsed use ':' after option
-while getopts ':n:i:b:m:o:O:vht' OPTION ; do
+while getopts ':n:i:b:m:o:O:B:vht' OPTION ; do
         case $OPTION in
 	v)        VERBOSE=$((VERBOSE+1))
                 ;;
@@ -195,6 +201,8 @@ while getopts ':n:i:b:m:o:O:vht' OPTION ; do
 	        ;;
 	b)	BACKGROUNDIMAGENAME="$OPTARG"
 		GENERATE_BACKGROUND=0
+		;;
+	B)      FILLUPCOLOR="$OPTARG"
 		;;
         t)      GENTMPDIR=1
                 ;;
@@ -230,10 +238,35 @@ for INPUTIMAGE in "$@"
 do
 	if [ $VERBOSE -ne 0 ] ; then  echo "processing $INPUTIMAGE"; fi
 
-	WIDTH=`identify -format "%w" "$INPUTIMAGE"`
-	HEIGHT=`identify -format "%h" "$INPUTIMAGE"`
-	if [ -z "$WIDTH"  -o -z "$HEIGHT" ] ; then failbail "cannot identify size of image $INPUTIMAGE" ; fi
-	if [ $VERBOSE -ne 0 ] ; then  echo "[debug] imagesize: $IMGSIZE $WIDTH $HEIGHT"; fi
+	if [ $GENERATE_BACKGROUND -ne 0 ] ; then
+		WIDTH=`identify -format "%w" "$INPUTIMAGE"`
+		HEIGHT=`identify -format "%h" "$INPUTIMAGE"`
+		if [ -z "$WIDTH"  -o -z "$HEIGHT" ] ; then 
+			failbail "cannot identify size of image $INPUTIMAGE" ; 
+		fi
+		# do this in the temporary directory
+		BACKGROUNDIMAGE="$TMPDIR/$BACKGROUNDIMAGENAME"
+		# generate 'starting' canvas
+		CMD="$CONVERT_BIN -size ${WIDTH}x$HEIGHT plasma:fractal $BACKGROUNDIMAGE"
+		if [ $VERBOSE -ne 0 ] ; then  echo $CMD; fi
+		eval $CMD
+		IMAGETOUSE=$INPUTIMAGE
+	else
+		BACKGROUNDIMAGE="$BACKGROUNDIMAGENAME"
+		WIDTH=`identify -format "%w" "$BACKGROUNDIMAGE"`
+		HEIGHT=`identify -format "%h" "$BACKGROUNDIMAGE"`
+		if [ -z "$WIDTH"  -o -z "$HEIGHT" ] ; then 
+			failbail "cannot identify size of image $BACKGROUNDIMAGE" ; 
+		fi
+		INPUTIMAGERESIZED="$TMPDIR/$RESIZEIMAGENAME"
+		CMD="$CONVERT_BIN \"$INPUTIMAGE\" -auto-orient -resize ${WIDTH}x$HEIGHT \
+			-background $FILLUPCOLOR -compose Copy -gravity center -extent ${WIDTH}x$HEIGHT \"$INPUTIMAGERESIZED\""
+		if [ $VERBOSE -ne 0 ] ; then  echo $CMD; fi
+		eval $CMD
+		IMAGETOUSE=$INPUTIMAGERESIZED
+	fi
+
+	if [ $VERBOSE -ne 0 ] ; then  echo "[debug] imagesize: $WIDTH $HEIGHT"; fi
 	
 	# generate a mask image
 	if [ $GENERATE_MASK -ne 0 ] ; then
@@ -246,16 +279,6 @@ do
 	# debug: convert labelled mask image to 256 colors
 	# convert -colors 256 -colorspace GRAY $MASKIMAGENAME ?
 	
-	if [ $GENERATE_BACKGROUND -ne 0 ] ; then
-		# do this in the temporary directory
-		BACKGROUNDIMAGE="$TMPDIR/$BACKGROUNDIMAGENAME"
-		# generate 'starting' canvas
-		CMD="$CONVERT_BIN -size ${WIDTH}x$HEIGHT plasma:fractal $BACKGROUNDIMAGE"
-		if [ $VERBOSE -ne 0 ] ; then  echo $CMD; fi
-		eval $CMD
-	else
-		BACKGROUNDIMAGE="$BACKGROUNDIMAGENAME"
-	fi
 	
 	# output name
 	if [ $RESULTIMAGEBASE_GIVEN -ne 0 ] 
@@ -279,7 +302,7 @@ do
 		eval $CMD
 		
 		# mask the image
-		CMD="$COMPOSITE_BIN \"$BACKGROUNDIMAGE\" \"$INPUTIMAGE\" \"$GRAYMASKFILE\" \"$RESULTIMAGE\""
+		CMD="$COMPOSITE_BIN \"$BACKGROUNDIMAGE\" \"$IMAGETOUSE\" \"$GRAYMASKFILE\" \"$RESULTIMAGE\""
 		if [ $VERBOSE -ne 0 ]; then  echo "$CMD" ; fi
 		eval $CMD
 		if [ $VERBOSE -ne 0 ]; then  echo "result image written to "$RESULTIMAGE ; fi


### PR DESCRIPTION
This changes the behaviour of dalliclick.sh in the following way:
- If a background image is specified, the output files will have exactly the size as the background image. The input image will be scaled before masking it. If the ratio of the input file does not fit to the background image it will be filled with a color. This color is selectable via the new option -B

This enhancement eases the processing of multiple input files that have different sizes.


  